### PR TITLE
Fix stale value_info on ONNX export and IndexError in powermetrics

### DIFF
--- a/video/conversion/_exporter/_onnx_utils.py
+++ b/video/conversion/_exporter/_onnx_utils.py
@@ -4,6 +4,7 @@
 import numpy as np
 import onnx
 import onnxscript
+from onnx import shape_inference
 from onnxscript import ir
 
 DEFAULT_ONNX_PASSES = [
@@ -57,6 +58,16 @@ class OnnxOptimizer:
                 self._qc_workaround_clip_min_only()
             else:
                 raise ValueError(f"Unknown pass: {pass_name}")
+
+        # Passes like qc_workaround_squeeze_gather_4d hand-craft new tensors
+        # and value_info entries without keeping the rest of the graph's
+        # shape info in sync. onnxruntime tolerates the resulting
+        # inconsistency, but AI Hub's strict onnx.checker rejects it with
+        # e.g. "Inferred shape and existing shape differ in rank: (2) vs
+        # (4)". Rebuild value_info from scratch so every saved model is
+        # internally consistent, regardless of which passes ran.
+        del self._model.graph.value_info[:]
+        self._model = shape_inference.infer_shapes(self._model)
         return self._model
 
     def _replace_reciprocal_op(self):

--- a/video/conversion/_powermetrics.py
+++ b/video/conversion/_powermetrics.py
@@ -82,7 +82,7 @@ class PowerMetricsCollector:
                     break
 
                 line = process.stdout.readline()
-                if line[0] == 0:
+                if line and line[0] == 0:
                     d = b"".join(buffer)
                     data = plistlib.loads(d)
                     row = PowermetricsSample(


### PR DESCRIPTION
## Summary
Two small, independent bug fixes found while exporting a model through the Qualcomm ONNX path and benchmarking on macOS:

- **`conversion/_exporter/_onnx_utils.py`**: `OnnxOptimizer`'s Gather-squeeze QNN workaround (`_qc_workaround_squeeze_gather_4d`) hand-crafts a `value_info` entry for an intermediate tensor without refreshing the rest of the graph's shape info afterward. `onnxruntime` tolerates the resulting inconsistency, but Qualcomm AI Hub's strict `onnx.checker.check_model(..., full_check=True)` rejects it with `ShapeInferenceError: Inferred shape and existing shape differ in rank`. Fix: clear `value_info` and re-run `onnx.shape_inference.infer_shapes()` at the end of every optimization pass, so the saved model is always internally consistent regardless of which passes ran.
- **`conversion/_powermetrics.py`**: `PowerMetricsCollector._run_apple` indexes into an empty `readline()` result (`if line[0] == 0`), which throws `IndexError` in a background thread whenever the `powermetrics` subprocess emits a blank line. Fix: guard with `if line and line[0] == 0`.

## Test plan
- [x] Reproduced the `value_info` failure on a 1080p (1920x1088) export through `convert.py export --model-type onnx --target-device qualcomm`; confirmed `onnx.checker.check_model(full_check=True)` now passes on all exported graphs (encoder part 1/2, decoder) with no manual post-processing.
- [x] Reproduced the `IndexError` via `convert.py export --benchmark` on macOS; confirmed the guard prevents the crash.